### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/gui-v2.yml
+++ b/.github/workflows/gui-v2.yml
@@ -68,7 +68,7 @@ jobs:
           echo Version $RELEASE_VERSION
           echo ::set-output name=version::$RELEASE_VERSION
     - name: Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ steps.get_owner.outputs.owner }}/gui-v2
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore